### PR TITLE
Add LSPatch compatibility

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
 
     <queries>
         <package android:name="com.zing.zalo" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
 
     <queries>
         <package android:name="com.zing.zalo" />

--- a/app/src/main/java/com/ez/zalopatch/ZaloArtifactIdentity.java
+++ b/app/src/main/java/com/ez/zalopatch/ZaloArtifactIdentity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
 import android.content.pm.Signature;
 import android.os.Build;
 
@@ -28,10 +29,19 @@ final class ZaloArtifactIdentity {
     final List<Split> splits;
     final String lightweightKey;
     final String generation;
+    /**
+     * True when the installed Zalo package was repackaged by LSPatch, detected by the
+     * loader-injected {@code *.lspatch.documents} provider every LSPatch build carries. LSPatch
+     * always resigns the APK with its own key, so {@link #signerSha256} never matches the
+     * original Zalo signer on a patched install; that resign is what LSPatch does by design, not
+     * evidence of a tampered artifact, so callers use this flag to relax the signer check instead
+     * of treating every LSPatch install as untrusted.
+     */
+    final boolean lspatched;
 
     private ZaloArtifactIdentity(long versionCode, String versionName, long lastUpdateTime,
                                  String sourceDir, String baseApkSha256, String signerSha256,
-                                 List<Split> splits) {
+                                 List<Split> splits, boolean lspatched) {
         this.versionCode = versionCode;
         this.versionName = versionName;
         this.lastUpdateTime = lastUpdateTime;
@@ -39,14 +49,16 @@ final class ZaloArtifactIdentity {
         this.baseApkSha256 = baseApkSha256;
         this.signerSha256 = signerSha256;
         this.splits = Collections.unmodifiableList(new ArrayList<>(splits));
+        this.lspatched = lspatched;
         this.lightweightKey = sha256(canonical(false));
         this.generation = baseApkSha256.isEmpty() ? "" : sha256(canonical(true));
     }
 
     static ZaloArtifactIdentity capture(Context context, boolean hashApks) throws Exception {
         PackageManager packageManager = context.getPackageManager();
-        int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
-                ? PackageManager.GET_SIGNING_CERTIFICATES : PackageManager.GET_SIGNATURES;
+        int flags = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+                ? PackageManager.GET_SIGNING_CERTIFICATES : PackageManager.GET_SIGNATURES)
+                | PackageManager.GET_PROVIDERS;
         PackageInfo info = packageManager.getPackageInfo(PACKAGE_NAME, flags);
         ApplicationInfo applicationInfo = info.applicationInfo;
         if (applicationInfo == null || applicationInfo.sourceDir == null) {
@@ -58,7 +70,19 @@ final class ZaloArtifactIdentity {
         List<Split> splits = splits(applicationInfo, hashApks);
         return new ZaloArtifactIdentity(code, info.versionName == null ? "" : info.versionName,
                 info.lastUpdateTime, applicationInfo.sourceDir, baseHash,
-                signerDigest(info), splits);
+                signerDigest(info), splits, isLspatched(info));
+    }
+
+    private static boolean isLspatched(PackageInfo info) {
+        if (info.providers == null) {
+            return false;
+        }
+        for (ProviderInfo provider : info.providers) {
+            if (provider.authority != null && provider.authority.contains("lspatch.documents")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static List<Split> splits(ApplicationInfo info, boolean hashApks) throws Exception {

--- a/app/src/main/java/com/ez/zalopatch/ZaloArtifactState.java
+++ b/app/src/main/java/com/ez/zalopatch/ZaloArtifactState.java
@@ -39,6 +39,13 @@ public final class ZaloArtifactState {
      * Symbols are accepted; per-anchor structural preflight remains the load-bearing check.
      */
     public static final String EVIDENCE_VERSION_SIGNER = "version_signer";
+    /**
+     * The installed artifact carries the profile's exact versionCode, but the Zalo signing
+     * certificate was replaced because LSPatch resigns every APK it patches. Detected via the
+     * loader-injected {@code lspatch.documents} provider (see {@link ZaloArtifactIdentity}), not
+     * from the signer digest itself, so an unrelated repack still falls through to a mismatch.
+     */
+    public static final String EVIDENCE_LSPATCH_RESIGNED = "lspatch_resigned";
     public static final String EVIDENCE_NONE = "none";
     /**
      * Authorized, but the stored state predates the match tier or has not been reconciled since.
@@ -148,10 +155,17 @@ public final class ZaloArtifactState {
             String verification = profile.string("artifact.verification", "unverified");
             String profileHash = profile.valid ? ZaloArtifactIdentity.sha256(profile.json) : "";
             Decision decision = decide(profile.valid, profile.validation, catalogStatus,
-                    expectedSigner, expectedHash, identity.signerSha256, identity.baseApkSha256);
+                    expectedSigner, expectedHash, identity.signerSha256, identity.baseApkSha256,
+                    identity.lspatched);
             String status = decision.status;
             String error = decision.error;
             String evidence = decision.evidence;
+            // authorizes() re-checks profileSigner.equals(storedSigner) on every hook launch. A
+            // resigned LSPatch install can never match the real Zalo signer, so what gets stored
+            // here for that case is the profile's own expected signer, matching the recomputed
+            // profileSigner value at hook time and keeping that check meaningful for everyone else.
+            String signerToStore = EVIDENCE_LSPATCH_RESIGNED.equals(evidence)
+                    ? expectedSigner : identity.signerSha256;
             if (generationChanged) {
                 clearSelfCheck(preferences);
             }
@@ -161,7 +175,7 @@ public final class ZaloArtifactState {
                     .putString(KEY_GENERATION, identity.generation)
                     .putLong(KEY_VERSION_CODE, identity.versionCode)
                     .putString(KEY_BASE_SHA256, identity.baseApkSha256)
-                    .putString(KEY_SIGNER_SHA256, identity.signerSha256)
+                    .putString(KEY_SIGNER_SHA256, signerToStore)
                     .putInt(KEY_PROFILE_REVISION, profile.schemaRevision)
                     .putString(KEY_PROFILE_SHA256, profileHash)
                     .putString(KEY_PROFILE_SOURCE, profile.source)
@@ -211,12 +225,15 @@ public final class ZaloArtifactState {
      */
     static Decision decide(boolean profileValid, String profileValidation, String catalogStatus,
                            String expectedSigner, String expectedBaseHash,
-                           String actualSigner, String actualBaseHash) {
+                           String actualSigner, String actualBaseHash, boolean lspatched) {
         if (!profileValid) {
             return new Decision("unsupported", EVIDENCE_NONE,
                     profileValidation + "; catalog " + catalogStatus);
         }
         if (expectedSigner == null || !expectedSigner.equals(actualSigner)) {
+            if (lspatched) {
+                return new Decision("ready", EVIDENCE_LSPATCH_RESIGNED, "");
+            }
             return new Decision("mismatch", EVIDENCE_NONE,
                     "Zalo signing certificate does not match the selected profile");
         }
@@ -338,6 +355,10 @@ public final class ZaloArtifactState {
             summary.append("\nBase APK container differs from the mapped one; matched on exact "
                     + "versionCode and Zalo signing certificate.");
         }
+        if (EVIDENCE_LSPATCH_RESIGNED.equals(evidence)) {
+            summary.append("\nZalo signing certificate differs because LSPatch resigned the APK; "
+                    + "matched on exact versionCode and the LSPatch loader marker instead.");
+        }
         if (reconcileSuppressed(context)) {
             summary.append("\nRe-check suppressed while com.ez.zalopatch.test is installed; "
                     + "uninstall it to resume artifact reconciliation.");
@@ -430,7 +451,8 @@ public final class ZaloArtifactState {
 
         /** True when the profile was mapped from a different container of the same release. */
         public boolean containerUnverified() {
-            return compatible && EVIDENCE_VERSION_SIGNER.equals(evidence);
+            return compatible && (EVIDENCE_VERSION_SIGNER.equals(evidence)
+                    || EVIDENCE_LSPATCH_RESIGNED.equals(evidence));
         }
     }
 

--- a/app/src/main/java/com/ez/zalopatch/ZaloRestart.java
+++ b/app/src/main/java/com/ez/zalopatch/ZaloRestart.java
@@ -1,6 +1,8 @@
 package com.ez.zalopatch;
 
+import android.app.ActivityManager;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -9,12 +11,15 @@ import java.io.InputStreamReader;
 import java.util.Locale;
 
 final class ZaloRestart {
+    private static final String TARGET_PACKAGE = "com.zing.zalo";
+
     interface Callback {
         void onResult(Result result);
     }
 
     enum Result {
         SENT,
+        SENT_NO_ROOT,
         ROOT_DENIED,
         FAILED
     }
@@ -31,11 +36,21 @@ final class ZaloRestart {
     }
 
     private static Result restartBlocking(Context context) {
+        // Best effort only: this is a cached fast-path for reads, not the source of truth. The
+        // module's ContentProvider always reflects the live SharedPreferences values, so a failed
+        // (unrooted) mirror write must not block relaunching the target app below.
+        TweakStore.syncProperties(context);
+        long changeGeneration = SettingsChanges.generation(context);
+        Result rootResult = restartWithRoot(context, changeGeneration);
+        if (rootResult != null) {
+            return rootResult;
+        }
+        return restartWithoutRoot(context, changeGeneration);
+    }
+
+    /** Returns null when no root is available, so the caller can fall back. */
+    private static Result restartWithRoot(Context context, long changeGeneration) {
         try {
-            long changeGeneration = SettingsChanges.generation(context);
-            if (!TweakStore.syncProperties(context)) {
-                return Result.ROOT_DENIED;
-            }
             Process process = new ProcessBuilder(
                     "su", "-c",
                     "am force-stop com.zing.zalo && monkey -p com.zing.zalo -c android.intent.category.LAUNCHER 1")
@@ -57,9 +72,40 @@ final class ZaloRestart {
             String message = output.toString().toLowerCase(Locale.US);
             if (message.contains("denied") || message.contains("not allowed")
                     || message.contains("permission")) {
-                return Result.ROOT_DENIED;
+                return null;
             }
             return Result.FAILED;
+        } catch (java.io.IOException noSuBinary) {
+            // No su binary at all: not a rooted device (e.g. a stock LSPatch install). Fall back.
+            return null;
+        } catch (Exception ignored) {
+            return Result.FAILED;
+        }
+    }
+
+    /**
+     * LSPatch commonly runs without root (that is its main appeal over LSPosed/Magisk), so a
+     * force-stop is not available. Kill whatever background copy exists and relaunch; a process
+     * that is not currently in the foreground is killable this way. If Zalo is in the foreground,
+     * the relaunch still brings it forward, but the running process keeps its already-hooked,
+     * already-cached settings until the user manually closes it from Recents.
+     */
+    private static Result restartWithoutRoot(Context context, long changeGeneration) {
+        try {
+            Object systemService = context.getSystemService(Context.ACTIVITY_SERVICE);
+            if (systemService instanceof ActivityManager) {
+                ((ActivityManager) systemService).killBackgroundProcesses(TARGET_PACKAGE);
+            }
+            Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(TARGET_PACKAGE);
+            if (launchIntent == null) {
+                return Result.FAILED;
+            }
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                    | Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+            context.startActivity(launchIntent);
+            SettingsChanges.clearIfGeneration(context, changeGeneration);
+            return Result.SENT_NO_ROOT;
         } catch (Exception ignored) {
             return Result.FAILED;
         }

--- a/app/src/main/java/com/ez/zalopatch/ZaloRestart.java
+++ b/app/src/main/java/com/ez/zalopatch/ZaloRestart.java
@@ -1,10 +1,11 @@
 package com.ez.zalopatch;
 
-import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.provider.Settings;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -19,7 +20,7 @@ final class ZaloRestart {
 
     enum Result {
         SENT,
-        SENT_NO_ROOT,
+        MANUAL_FORCE_STOP_NEEDED,
         ROOT_DENIED,
         FAILED
     }
@@ -45,7 +46,7 @@ final class ZaloRestart {
         if (rootResult != null) {
             return rootResult;
         }
-        return restartWithoutRoot(context, changeGeneration);
+        return restartWithoutRoot(context);
     }
 
     /** Returns null when no root is available, so the caller can fall back. */
@@ -84,28 +85,18 @@ final class ZaloRestart {
     }
 
     /**
-     * LSPatch commonly runs without root (that is its main appeal over LSPosed/Magisk), so a
-     * force-stop is not available. Kill whatever background copy exists and relaunch; a process
-     * that is not currently in the foreground is killable this way. If Zalo is in the foreground,
-     * the relaunch still brings it forward, but the running process keeps its already-hooked,
-     * already-cached settings until the user manually closes it from Recents.
+     * LSPatch commonly runs without root (that is its main appeal over LSPosed/Magisk), so this
+     * app cannot force-stop another app itself. Send the user to Zalo's App info screen instead,
+     * where a manual "Force stop" is one tap away; the toast (see the caller) tells them why.
+     * Pending changes are deliberately left marked, since nothing has actually been applied yet.
      */
-    private static Result restartWithoutRoot(Context context, long changeGeneration) {
+    private static Result restartWithoutRoot(Context context) {
         try {
-            Object systemService = context.getSystemService(Context.ACTIVITY_SERVICE);
-            if (systemService instanceof ActivityManager) {
-                ((ActivityManager) systemService).killBackgroundProcesses(TARGET_PACKAGE);
-            }
-            Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(TARGET_PACKAGE);
-            if (launchIntent == null) {
-                return Result.FAILED;
-            }
-            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
-                    | Intent.FLAG_ACTIVITY_CLEAR_TOP
-                    | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-            context.startActivity(launchIntent);
-            SettingsChanges.clearIfGeneration(context, changeGeneration);
-            return Result.SENT_NO_ROOT;
+            Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.parse("package:" + TARGET_PACKAGE));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            context.startActivity(intent);
+            return Result.MANUAL_FORCE_STOP_NEEDED;
         } catch (Exception ignored) {
             return Result.FAILED;
         }

--- a/app/src/main/java/com/ez/zalopatch/ZpSettingsActivity.java
+++ b/app/src/main/java/com/ez/zalopatch/ZpSettingsActivity.java
@@ -129,12 +129,14 @@ abstract class ZpSettingsActivity extends AppCompatActivity {
         onRestartStateChanged(false);
         int message = result == ZaloRestart.Result.SENT
                 ? R.string.zp_restart_sent
-                : result == ZaloRestart.Result.SENT_NO_ROOT
-                ? R.string.zp_restart_sent_no_root
+                : result == ZaloRestart.Result.MANUAL_FORCE_STOP_NEEDED
+                ? R.string.zp_restart_manual_force_stop_needed
                 : result == ZaloRestart.Result.ROOT_DENIED
                 ? R.string.zp_restart_root_denied
                 : R.string.zp_restart_failed;
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+        int toastDuration = result == ZaloRestart.Result.MANUAL_FORCE_STOP_NEEDED
+                ? Toast.LENGTH_LONG : Toast.LENGTH_SHORT;
+        Toast.makeText(this, message, toastDuration).show();
         refreshApplyBar(true);
         onRestartResult(result);
     }

--- a/app/src/main/java/com/ez/zalopatch/ZpSettingsActivity.java
+++ b/app/src/main/java/com/ez/zalopatch/ZpSettingsActivity.java
@@ -129,6 +129,8 @@ abstract class ZpSettingsActivity extends AppCompatActivity {
         onRestartStateChanged(false);
         int message = result == ZaloRestart.Result.SENT
                 ? R.string.zp_restart_sent
+                : result == ZaloRestart.Result.SENT_NO_ROOT
+                ? R.string.zp_restart_sent_no_root
                 : result == ZaloRestart.Result.ROOT_DENIED
                 ? R.string.zp_restart_root_denied
                 : R.string.zp_restart_failed;

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -11,7 +11,7 @@
     -->
     <string name="zp_restart_title">Khởi động lại Zalo</string>
     <string name="zp_restart_sent">Đã gửi lệnh khởi động lại</string>
-    <string name="zp_restart_sent_no_root">Đã mở lại Zalo (không root). Hãy đóng Zalo trong Recents nếu thay đổi chưa áp dụng</string>
+    <string name="zp_restart_manual_force_stop_needed">Không có root: đang mở thông tin ứng dụng Zalo. Nhấn Buộc dừng, sau đó mở lại Zalo để áp dụng thay đổi</string>
     <string name="zp_restart_root_denied">Quyền root bị từ chối</string>
     <string name="zp_restart_failed">Không thể khởi động lại</string>
     <string name="zp_section_status">Trạng thái</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -11,6 +11,7 @@
     -->
     <string name="zp_restart_title">Khởi động lại Zalo</string>
     <string name="zp_restart_sent">Đã gửi lệnh khởi động lại</string>
+    <string name="zp_restart_sent_no_root">Đã mở lại Zalo (không root). Hãy đóng Zalo trong Recents nếu thay đổi chưa áp dụng</string>
     <string name="zp_restart_root_denied">Quyền root bị từ chối</string>
     <string name="zp_restart_failed">Không thể khởi động lại</string>
     <string name="zp_section_status">Trạng thái</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <!-- Dashboard -->
     <string name="zp_restart_title">Restart Zalo</string>
     <string name="zp_restart_sent">Restart command sent</string>
-    <string name="zp_restart_sent_no_root">Zalo relaunched (no root). Close it from Recents if changes don\'t apply</string>
+    <string name="zp_restart_manual_force_stop_needed">No root: opening Zalo\'s app info. Tap Force stop, then reopen Zalo to apply changes</string>
     <string name="zp_restart_root_denied">Root access denied</string>
     <string name="zp_restart_failed">Restart command failed</string>
     <string name="zp_runtime_status_title">Runtime status</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <!-- Dashboard -->
     <string name="zp_restart_title">Restart Zalo</string>
     <string name="zp_restart_sent">Restart command sent</string>
+    <string name="zp_restart_sent_no_root">Zalo relaunched (no root). Close it from Recents if changes don\'t apply</string>
     <string name="zp_restart_root_denied">Root access denied</string>
     <string name="zp_restart_failed">Restart command failed</string>
     <string name="zp_runtime_status_title">Runtime status</string>

--- a/app/src/test/java/com/ez/zalopatch/ZaloArtifactGateTest.java
+++ b/app/src/test/java/com/ez/zalopatch/ZaloArtifactGateTest.java
@@ -24,7 +24,7 @@ public final class ZaloArtifactGateTest {
     @Test
     public void mappedContainerReportsExactApkEvidence() {
         ZaloArtifactState.Decision decision = ZaloArtifactState.decide(
-                true, "", "cached", SIGNER, MAPPED_APK, SIGNER, MAPPED_APK);
+                true, "", "cached", SIGNER, MAPPED_APK, SIGNER, MAPPED_APK, false);
 
         assertEquals("ready", decision.status);
         assertEquals(ZaloArtifactState.EVIDENCE_EXACT_APK, decision.evidence);
@@ -34,7 +34,7 @@ public final class ZaloArtifactGateTest {
     @Test
     public void otherContainerOfSameReleaseStaysReadyAsUnverifiedMatch() {
         ZaloArtifactState.Decision decision = ZaloArtifactState.decide(
-                true, "", "cached", SIGNER, MAPPED_APK, SIGNER, VARIANT_APK);
+                true, "", "cached", SIGNER, MAPPED_APK, SIGNER, VARIANT_APK, false);
 
         assertEquals("ready", decision.status);
         assertEquals(ZaloArtifactState.EVIDENCE_VERSION_SIGNER, decision.evidence);
@@ -44,10 +44,25 @@ public final class ZaloArtifactGateTest {
     @Test
     public void foreignSignerIsRejected() {
         ZaloArtifactState.Decision decision = ZaloArtifactState.decide(
-                true, "", "cached", SIGNER, MAPPED_APK, "00" + SIGNER.substring(2), MAPPED_APK);
+                true, "", "cached", SIGNER, MAPPED_APK, "00" + SIGNER.substring(2), MAPPED_APK,
+                false);
 
         assertEquals("mismatch", decision.status);
         assertEquals(ZaloArtifactState.EVIDENCE_NONE, decision.evidence);
+    }
+
+    @Test
+    public void lspatchResignedInstallStaysReadyAsLspatchResignedEvidence() {
+        // LSPatch always resigns the patched APK with its own key, so the observed signer never
+        // matches the original Zalo signer on a patched install. The loader-injected
+        // *.lspatch.documents provider is what actually distinguishes this from a foreign repack.
+        ZaloArtifactState.Decision decision = ZaloArtifactState.decide(
+                true, "", "cached", SIGNER, MAPPED_APK, "00" + SIGNER.substring(2), MAPPED_APK,
+                true);
+
+        assertEquals("ready", decision.status);
+        assertEquals(ZaloArtifactState.EVIDENCE_LSPATCH_RESIGNED, decision.evidence);
+        assertEquals("", decision.error);
     }
 
     @Test
@@ -79,7 +94,7 @@ public final class ZaloArtifactGateTest {
     public void versionWithoutProfileIsUnsupported() {
         ZaloArtifactState.Decision decision = ZaloArtifactState.decide(
                 false, "no exact profile for installed Zalo", "missing",
-                "", "", SIGNER, VARIANT_APK);
+                "", "", SIGNER, VARIANT_APK, false);
 
         assertEquals("unsupported", decision.status);
         assertEquals(ZaloArtifactState.EVIDENCE_NONE, decision.evidence);


### PR DESCRIPTION
## Summary
- The settings Apply flow required root for both the property-mirror cache write and the force-stop+relaunch, so it silently failed on non-rooted LSPatch installs. It now falls back to opening Zalo's App info screen and prompting the user to tap Force stop themselves when no `su` is available.
- The artifact-compatibility gate required the installed Zalo's signing certificate to exactly match the original Play Store signer, which LSPatch can never satisfy since it resigns every APK it patches. This left every real hook disabled under LSPatch even with a valid symbol profile (self-check showed `zalo_artifact` staying `mismatch` while the symbol probe resolved all anchors). The gate now recognizes an LSPatch-repackaged install via the loader-injected `*.lspatch.documents` provider and accepts the resign under a new `EVIDENCE_LSPATCH_RESIGNED` tier, while any other signer mismatch is still rejected as before.

## Test plan
- [x] Added/updated unit tests in `ZaloArtifactGateTest` covering the new LSPatch-resigned tier
- [x] Verified on-device via adb (LSPatch, non-root) that `ConfigProvider` reads correctly and that the previous `zalo_artifact: mismatch` status is what blocked hooking; confirmed the new tier flips it to `ready` with hooks running
- [ ] Manual test on a rooted LSPosed install to confirm no regression (I dont have root device)